### PR TITLE
pip19 removed process_dependency_links.

### DIFF
--- a/lib/poise_python/resources/python_package.rb
+++ b/lib/poise_python/resources/python_package.rb
@@ -70,10 +70,11 @@ with cmd._build_session(options) as session:
     find_links=options.find_links,
     index_urls=index_urls,
     allow_all_prereleases=options.pre,
-    process_dependency_links=options.process_dependency_links,
     trusted_hosts=options.trusted_hosts,
     session=session,
   )
+  if getattr(options, 'process_dependency_links', None):
+    finder_options['process_dependency_links'] = options.process_dependency_links
   if getattr(options, 'format_control', None):
     finder_options['format_control'] = options.format_control
   finder = PackageFinder(**finder_options)


### PR DESCRIPTION
* Add a check to see if process_dependency_links is supported.